### PR TITLE
chore: replace export PS4 with p6_env_export and echo with p6_msg

### DIFF
--- a/lib/profile.zsh
+++ b/lib/profile.zsh
@@ -16,11 +16,11 @@ p6df::modules::zsh::profile::on() {
     zmodload zsh/datetime
     setopt PROMPT_SUBST
     PS4='+$EPOCHREALTIME %N:%i> '
-    export PS4
+    p6_env_export "PS4" "$PS4"
 
     local logfile
     logfile=$(mktemp "$name-zsh.XXXXXXXX")
-    echo "Logging to $logfile"
+    p6_msg "Logging to $logfile"
     exec 3>&2 2>"$logfile"
 
     setopt XTRACE
@@ -41,7 +41,7 @@ p6df::modules::zsh::profile::off() {
     unsetopt XTRACE
 
     PS4='+%N:%i>'
-    export PS4
+    p6_env_export "PS4" "$PS4"
 
     exec 2>&3 3>&-
 }


### PR DESCRIPTION
## Summary

- Replace raw `export PS4` with `p6_env_export "PS4" "$PS4"` in `lib/profile.zsh:19,44`
- Replace `echo "Logging to $logfile"` with `p6_msg "Logging to $logfile"` in `lib/profile.zsh:23`

Note: credential exports elsewhere are intentionally raw and are not changed.

## Test plan

- [ ] `p6df::modules::zsh::profile::on` sets PS4 and logs to file correctly
- [ ] `p6df::modules::zsh::profile::off` resets PS4 correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)