### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -44,11 +44,11 @@ p6df::modules::zsh::external::yum() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::zsh::external::brew()
+# Function: p6df::modules::zsh::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::zsh::external::brew() {
+p6df::modules::zsh::external::brews() {
 
   p6df::core::homebrew::cli::brew::install zsh
   p6df::core::homebrew::cli::brew::install zmap


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly