### PR TITLE
fix(state): replace nonexistent p6_file_remove with p6_file_rmf

### DIFF
--- a/lib/state.zsh
+++ b/lib/state.zsh
@@ -27,7 +27,7 @@ p6df::modules::zsh::state::off() {
 ######################################################################
 p6df::modules::zsh::state::on() {
 
-  p6_file_remove "${ZDOTDIR}/.zshrc"
+  p6_file_rmf "${ZDOTDIR}/.zshrc"
 
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-core/conf/zshrc" "${ZDOTDIR}/.zshrc"
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-core/conf/zshenv" "${ZDOTDIR}/.zshenv"


### PR DESCRIPTION
## What
Replace call to `p6_file_remove` with `p6_file_rmf` in `lib/state.zsh:30`.

## Why
`p6_file_remove` does not exist in p6common. `p6_file_rmf` is the correct function (`rm -f`).

## Test plan
- Verified `p6_file_rmf` exists in p6common/lib/stdio/file.sh

## Dependencies
None