### PR TITLE
refactor(zsh): rename profile::on/off to profiling::on/off

### DIFF
--- a/lib/profile.zsh
+++ b/lib/profile.zsh
@@ -2,7 +2,7 @@
 ######################################################################
 #<
 #
-# Function: p6df::modules::zsh::profile::on(name)
+# Function: p6df::modules::zsh::profiling::on(name)
 #
 #  Args:
 #	name -
@@ -10,7 +10,7 @@
 #  Environment:	 EPOCHREALTIME PS4
 #>
 ######################################################################
-p6df::modules::zsh::profile::on() {
+p6df::modules::zsh::profiling::on() {
     local name="$1"
 
     zmodload zsh/datetime
@@ -30,12 +30,12 @@ p6df::modules::zsh::profile::on() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::zsh::profile::off()
+# Function: p6df::modules::zsh::profiling::off()
 #
 #  Environment:	 PS4
 #>
 ######################################################################
-p6df::modules::zsh::profile::off() {
+p6df::modules::zsh::profiling::off() {
 
     set +x
     unsetopt XTRACE


### PR DESCRIPTION
## What
Rename `p6df::modules::zsh::profile::on/off` to `p6df::modules::zsh::profiling::on/off` in `lib/profile.zsh`.

## Why
The original `profile` namespace collides with shell profile activation semantics. Using `profiling` as the sub-namespace makes the intent explicit (zsh execution tracing / profiling) and avoids confusion with profile sourcing/activation.

## Test plan
- Reviewed `lib/profile.zsh` to confirm both functions are renamed consistently
- No other callers of the old names exist in this repo

## Dependencies
None