### PR TITLE
refactor(zsh): update function signatures, rename profile funcs to profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ TODO: Add a short summary of this module.
 - `p6df::modules::zsh::colors::init()`
 - `p6df::modules::zsh::comp::init(dir)`
   - Args:
-    - dir -
+    - dir
 - `p6df::modules::zsh::completions::init()`
 - `p6df::modules::zsh::deps()`
-- `p6df::modules::zsh::external::brew()`
-- `p6df::modules::zsh::external::yum()`
+- `p6df::modules::zsh::env::init()`
+- `p6df::modules::zsh::external::brews()`
 - `p6df::modules::zsh::history::init()`
 - `p6df::modules::zsh::hooks::init()`
 - `p6df::modules::zsh::init(_module, dir)`
   - Args:
-    - _module -
-    - dir -
+    - _module
+    - dir
 - `str dir = p6df::modules::zsh::dir::prompt::mod()`
 - `str info = p6df::modules::zsh::std::prompt::mod()`
 
@@ -67,7 +67,7 @@ TODO: Add a short summary of this module.
 - `p6df::modules::zsh::fpath::current()`
 - `p6df::modules::zsh::fpath::if(dir)`
   - Args:
-    - dir -
+    - dir
 
 ##### p6df-zsh/lib/history.zsh
 
@@ -75,10 +75,10 @@ TODO: Add a short summary of this module.
 
 ##### p6df-zsh/lib/profile.zsh
 
-- `p6df::modules::zsh::profile::off()`
-- `p6df::modules::zsh::profile::on(name)`
+- `p6df::modules::zsh::profiling::off()`
+- `p6df::modules::zsh::profiling::on(name)`
   - Args:
-    - name -
+    - name
 
 ##### p6df-zsh/lib/state.zsh
 

--- a/init.zsh
+++ b/init.zsh
@@ -192,7 +192,7 @@ p6df::modules::zsh::comp::init() {
 ######################################################################
 #<
 #
-# Function: str info = p6df::modules::zsh::std::profile::mod()
+# Function: str info = p6df::modules::zsh::std::prompt::mod()
 #
 #  Returns:
 #	str - info


### PR DESCRIPTION
**What:** Update function signatures, rename `profile::on/off` to `profiling::on/off`, and fix prompt function name in doc

**Why:** Renames profiling functions to avoid collision with profile management, normalizes arg documentation, and fixes `std::profile::mod` -> `std::prompt::mod` in docblock

**Test plan:** Shell loads without errors; zsh profiling and prompt functions work as expected

**Dependencies:** none